### PR TITLE
Use MooX::ShortHas in multiple roles

### DIFF
--- a/lib/MooX/ShortHas.pm
+++ b/lib/MooX/ShortHas.pm
@@ -92,7 +92,7 @@ L<Mus> - Mu but with slightly more typing and strict constructors
 
 =cut
 
-use Moo::_Utils;
+use Moo::_Utils qw(_install_tracked);
 
 sub _modified_has {
     my ( $has, $mod, $name, @args ) = @_;
@@ -107,7 +107,7 @@ sub import {
         map { $_ => [ is => $_ => required => 1 ] } qw( ro rwp rw )
     );
     for my $mod ( keys %mods ) {
-        _install_coderef $caller. "::$mod" => sub {
+        _install_tracked $caller => $mod => sub {
             _modified_has $has, $mods{$mod}, @_;
         };
     }

--- a/t/roles.t
+++ b/t/roles.t
@@ -1,0 +1,36 @@
+use strictures 2;
+
+use Test::InDistDir;
+use Test::More;
+use Test::Fatal;
+
+BEGIN {
+    package RoleA;
+    use Moo::Role;
+    use MooX::ShortHas;
+    ro 'attr1';
+
+    package RoleB;
+    use Moo::Role;
+    use MooX::ShortHas;
+    ro 'attr2';
+
+    package Thing;
+    use Moo;
+}
+
+run();
+done_testing;
+exit;
+
+sub run {
+    my $class;
+    ok ! exception {
+        $class = Moo::Role->create_class_with_roles('Thing', qw(RoleA RoleB));
+    }, 'can apply roles';
+    my $thing = $class->new( attr1 => 'a', attr2 => 'b' );
+    ok $thing->can('attr1'), 'has attr1';
+    ok $thing->can('attr2'), 'has attr2';
+
+    return;
+}


### PR DESCRIPTION
This lets `Role::Tiny` know that that installed coderefs are not methods that need to be resolved.